### PR TITLE
[Client] Fix `async` typo in actions/trips.js that prevented Trips from rendering

### DIFF
--- a/client/src/redux/actions/trips.js
+++ b/client/src/redux/actions/trips.js
@@ -26,7 +26,7 @@ const token = localStorage.getItem("jwt")
 // Set token as Authorization header on all requests:
 axios.defaults.headers.common["Authorization"] = token
 
-export const getTrips = () => async dispatch => {
+export const getTrips = () => dispatch => {
   dispatch({ type: LOADING_TRIPS })
   return axios
     .get(`${SERVER_URI}/trips`)


### PR DESCRIPTION
# Description

1-word change to the trips action file: need to remove `async` from `getTrips` function so client doesn't try to re-set headers on every request.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
