### PR TITLE
Remove get_user_by_token call, update to regular axios call for user

### DIFF
--- a/client/src/redux/actions/auth.js
+++ b/client/src/redux/actions/auth.js
@@ -116,10 +116,10 @@ export const checkDbForUser = token => dispatch => {
     })
 
   axios
-    .get(`${SERVER_URI}/user_from_token/${id}`)
+    .get(`${SERVER_URI}/users/${id}`)
     .then(res => {
       dispatch({ type: QUERYING_USER_BY_TOKEN_SUCCESS, payload: res.data })
-      dispatch(push("/app"))
+      dispatch(push("/app/trips"))
     })
     .catch(err => {
       dispatch({ type: QUERYING_USER_BY_TOKEN_ERROR, payload: err })
@@ -195,7 +195,7 @@ export const loginWithOauth = () => dispatch => {
           localStorage.setItem("token", token)
           dispatch(addTokenToState())
 
-          dispatch(push("/app/trips"))
+          dispatch(push("/app/trip/create"))
         })
         .catch(err => {
           dispatch({ type: LOGIN_FAILURE, payload: err })

--- a/server/src/api/modules/auth.js
+++ b/server/src/api/modules/auth.js
@@ -80,19 +80,6 @@ export const protect = (req, res, next) => {
   })
 }
 
-export const getUserFromToken = (req, res) => {
-  const { id } = req.params
-
-  return User.findById(id)
-    .then(user => {
-      return res.status(200).json(user)
-    })
-    .catch(err => {
-      console.error(err)
-      return res.status(401).send("Unauthorized")
-    })
-}
-
 export const changePassword = async (req, res) => {
   const { username, oldPassword, newPassword } = req.body
   // find if old password is valid

--- a/server/src/api/restRouter.js
+++ b/server/src/api/restRouter.js
@@ -2,13 +2,7 @@ import express from "express"
 import { userRouter } from "./resources/user"
 import { tripRouter } from "./resources/trip"
 import { waypointRouter } from "./resources/waypoint"
-import {
-  protect,
-  register,
-  login,
-  getUserFromToken,
-  changePassword
-} from "./modules/auth"
+import { protect, register, login, changePassword } from "./modules/auth"
 import { subscribeRouter } from "./resources/subscribe"
 import { emailRouter } from "./resources/email"
 
@@ -17,7 +11,6 @@ export const restRouter = express.Router()
 restRouter.route("/register").post(register)
 restRouter.route("/login").post(login)
 restRouter.route("/changePassword").post(changePassword)
-restRouter.route("/user_from_token/:id").get(getUserFromToken)
 restRouter.use("/users", userRouter)
 // restRouter.use("/users", protect, userRouter)
 restRouter.use("/trips", protect, tripRouter)


### PR DESCRIPTION
# Description

Fix unnecessary call to `get_user_by_token` in auth actions, replace with GET to `users/:id`. Delete unnecessary enpoint.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
