### PR TITLE
[Backend] Add `/waypoints/batch` endpoint for creating many waypoints

### DIFF
--- a/client/src/components/Maps/createTrip/createTripPanel.js
+++ b/client/src/components/Maps/createTrip/createTripPanel.js
@@ -258,7 +258,6 @@ class CreateTripPanel extends React.Component {
       Axios.post(`${SERVER_URI}/trips/`, {
         userId: this.props.userId,
         lat: this.state.center.lat,
-        isArchieved: false,
         lon: this.state.center.lng,
         waypoints: this.state.waypoints,
         start: this.state.startDate.utc().format(),

--- a/server/src/api/resources/waypoint/waypoint.controller.js
+++ b/server/src/api/resources/waypoint/waypoint.controller.js
@@ -128,7 +128,7 @@ export const deleteWaypointsByTrip = (req, res) => {
     })
 }
 
-export const updateManyWaypoints = (req, res) => {
+export const createManyWaypoints = (req, res) => {
   const { tripId } = req.params
   const waypoints = req.body.waypoints.map(
     ({ order, name, lat, lon, start, end }) =>

--- a/server/src/api/resources/waypoint/waypoint.controller.js
+++ b/server/src/api/resources/waypoint/waypoint.controller.js
@@ -129,12 +129,13 @@ export const deleteWaypointsByTrip = (req, res) => {
 }
 
 export const updateManyWaypoints = (req, res) => {
+  const { tripId } = req.params
   const waypoints = req.body.waypoints.map(
-    ({ tripId, order, name, lat, lon, start, end }) =>
+    ({ order, name, lat, lon, start, end }) =>
       new Waypoint({ tripId, order, name, lat, lon, start, end })
   )
 
-  Waypoint.insert(waypoints)
+  Waypoint.insertMany(waypoints)
     .then(response => {
       Trip.findByIdAndUpdate(
         { _id: tripId },

--- a/server/src/api/resources/waypoint/waypoint.controller.js
+++ b/server/src/api/resources/waypoint/waypoint.controller.js
@@ -81,7 +81,7 @@ export const updateWaypoint = (req, res) => {
 export const deleteWaypoint = (req, res) => {
   Waypoint.findOneAndDelete({ _id: req.params.id })
     .then(waypoint => {
-      if (!waypoint) return res.status(404).send("Waypoint Not Found")
+      if (!waypoint) return res.status(404).json("Waypoint Not Found")
       Trip.findOneAndUpdate(
         { _id: req.body.tripId },
         { $pull: { waypoints: waypoint.id } }
@@ -129,7 +129,7 @@ export const deleteWaypointsByTrip = (req, res) => {
 }
 
 export const createManyWaypoints = (req, res) => {
-  const { tripId } = req.params
+  let { tripId } = req.body.waypoints[0]
   const waypoints = req.body.waypoints.map(
     ({ order, name, lat, lon, start, end }) =>
       new Waypoint({ tripId, order, name, lat, lon, start, end })

--- a/server/src/api/resources/waypoint/waypoint.controller.js
+++ b/server/src/api/resources/waypoint/waypoint.controller.js
@@ -10,6 +10,7 @@ export const getAllWaypoints = (req, res) => {
       res.status(500).send(err)
     })
 }
+
 export const createWaypoint = (req, res) => {
   const newWaypoint = new Waypoint({
     tripId: req.body.tripId,
@@ -124,5 +125,33 @@ export const deleteWaypointsByTrip = (req, res) => {
     })
     .catch(() => {
       res.status(404).json("No Waypoints found for specified Trip")
+    })
+}
+
+export const updateManyWaypoints = (req, res) => {
+  const waypoints = req.body.waypoints.map(
+    ({ tripId, order, name, lat, lon, start, end }) =>
+      new Waypoint({ tripId, order, name, lat, lon, start, end })
+  )
+
+  Waypoint.insert(waypoints)
+    .then(response => {
+      Trip.findByIdAndUpdate(
+        { _id: tripId },
+        {
+          $addToSet: {
+            waypoints: { $each: [...waypoints.map(({ id }) => id)] }
+          }
+        }
+      )
+        .then(() => {
+          res.status(201).json(response)
+        })
+        .catch(() => {
+          res.status(500).json("Error linking waypoints to Trip")
+        })
+    })
+    .catch(err => {
+      res.status(500).json(err.message)
     })
 }

--- a/server/src/api/resources/waypoint/waypoint.restRouter.js
+++ b/server/src/api/resources/waypoint/waypoint.restRouter.js
@@ -21,4 +21,4 @@ waypointRouter
 
 waypointRouter
   .route("/batch/:tripId")
-  .put(waypointController.updateManyWaypoints)
+  .put(waypointController.createManyWaypoints)

--- a/server/src/api/resources/waypoint/waypoint.restRouter.js
+++ b/server/src/api/resources/waypoint/waypoint.restRouter.js
@@ -19,4 +19,6 @@ waypointRouter
   .get(waypointController.getWaypointsByTrip)
   .delete(waypointController.deleteWaypointsByTrip)
 
-waypointRouter.route("/batch").put(waypointController.updateManyWaypoints)
+waypointRouter
+  .route("/batch/:tripId")
+  .put(waypointController.updateManyWaypoints)

--- a/server/src/api/resources/waypoint/waypoint.restRouter.js
+++ b/server/src/api/resources/waypoint/waypoint.restRouter.js
@@ -18,3 +18,5 @@ waypointRouter
   .route("/trip/:tripId")
   .get(waypointController.getWaypointsByTrip)
   .delete(waypointController.deleteWaypointsByTrip)
+
+waypointRouter.route("/batch").put(waypointController.updateManyWaypoints)

--- a/server/src/api/resources/waypoint/waypoint.restRouter.js
+++ b/server/src/api/resources/waypoint/waypoint.restRouter.js
@@ -9,16 +9,14 @@ waypointRouter
   .post(waypointController.createWaypoint)
 
 waypointRouter
-  .route("/:id")
-  .get(waypointController.getWaypoint)
-  .put(waypointController.updateWaypoint)
-  .delete(waypointController.deleteWaypoint)
-
-waypointRouter
   .route("/trip/:tripId")
   .get(waypointController.getWaypointsByTrip)
   .delete(waypointController.deleteWaypointsByTrip)
 
+waypointRouter.route("/batch").put(waypointController.createManyWaypoints)
+
 waypointRouter
-  .route("/batch/:tripId")
-  .put(waypointController.createManyWaypoints)
+  .route("/:id")
+  .get(waypointController.getWaypoint)
+  .put(waypointController.updateWaypoint)
+  .delete(waypointController.deleteWaypoint)

--- a/server/src/api/restRouter.js
+++ b/server/src/api/restRouter.js
@@ -18,10 +18,14 @@ restRouter.route("/register").post(register)
 restRouter.route("/login").post(login)
 restRouter.route("/changePassword").post(changePassword)
 restRouter.route("/user_from_token/:id").get(getUserFromToken)
-restRouter.use("/users", userRouter)
+
 // restRouter.use("/users", protect, userRouter)
-restRouter.use("/trips", protect, tripRouter)
-restRouter.use("/waypoints", protect, waypointRouter)
+// restRouter.use("/trips", protect, tripRouter)
+// restRouter.use("/waypoints", protect, waypointRouter)
+
+restRouter.use("/users", userRouter)
+restRouter.use("/trips", tripRouter)
+restRouter.use("/waypoints", waypointRouter)
 restRouter.use("/subscribe", protect, subscribeRouter)
 
 restRouter.use("/reset_password", emailRouter)


### PR DESCRIPTION
# Description

Created a `createManyWaypoints` route handler and mounted a PUT route at `/waypoints/batch` for creating many waypoints.

`/waypoints/batch` expects an array of waypoint objects that each satisfy the waypoints model.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Have not written tests yet.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
