### PR TITLE
[Client] Fix pending state bug on registration

### DIFF
--- a/client/src/redux/reducers/auth.js
+++ b/client/src/redux/reducers/auth.js
@@ -72,7 +72,11 @@ export const authReducer = (state = defaultState, action) => {
         user: { username, email }
       }
     case REGISTRATION_FAILURE:
-      return { ...state, error: normalizeErrorMsg(action.payload) }
+      return {
+        ...state,
+        pending: false,
+        error: normalizeErrorMsg(action.payload)
+      }
 
     case ADD_TOKEN_TO_STATE:
       return { ...state, token: action.payload }


### PR DESCRIPTION
# Description

Fixes a state bug where pending remains true when the `REGISTRATION_FAILURE` fires. This PR sets it back to false, which gets rid of the hanging loading animation that Frank reported.

Fixes #76 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tried to sign up with existing username, pending set back to true and animation stops.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
