### PR TITLE
Add script to install latest version of yarn in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
 
 before_install:
   - chmod +x scripts/test
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+  - export PATH="$HOME/.yarn/bin:$PATH"
 
 cache:
   yarn: true

--- a/server/tests/modules/testUser.js
+++ b/server/tests/modules/testUser.js
@@ -70,7 +70,6 @@ describe("Test User model and routes", () => {
       .get(`/api/users/${userID}/trips`)
       .set("Authorization", `Bearer ${token}`)
       .then(response => {
-        console.log(response.body)
         expect(response.statusCode).toBe(200)
         expect(response.body.length).toEqual(1)
         expect(response.body[0].userId).toBe(userID)


### PR DESCRIPTION
# Description
Team members of LabsPT1_Backwoods, hear me and rejoice! For a new dawn has arrived. No longer will we be chained to an old, deprecated version `yarn`. No longer will `[DEP0005] DeprecationWarning: Buffer() is deprecated` clog and mar our CI log.

Or maybe I was the only one bothered by those things! So yeah, I did some things. Added a couple of `before_script` commands in our `.travis.yml` file. It's set right now to use the current stable version of `yarn`. Everyone feel free to upgrade your yarn on your local machine!

@ahrjarrett Is this change okay for our Heroku deployment? I'm not seeing anything in our codebase that locks our version for Heroku, but I just want to make sure