### PR TITLE
[Bug Fix] Raise mobile add waypoint icon/button higher on screen

### DIFF
--- a/client/src/components/Maps/singleTrip/components/index.js
+++ b/client/src/components/Maps/singleTrip/components/index.js
@@ -29,11 +29,6 @@ export const TripPanelStyles = styled.div`
       display: flex;
     }
   }
-
-  #plus-icon {
-    z-index: 3;
-    bottom: 80px;
-  }
 `
 
 export const Panel = styled.div`

--- a/client/src/components/Maps/singleTrip/index.js
+++ b/client/src/components/Maps/singleTrip/index.js
@@ -68,7 +68,7 @@ class SingleTripMap extends React.Component {
       this.mapRef.current,
       {
         center: center,
-        zoom: 12,
+        zoom: 14,
         disableDefaultUI: true
       }
     )

--- a/client/src/components/MobileMapPanel.js
+++ b/client/src/components/MobileMapPanel.js
@@ -68,6 +68,10 @@ const MobileMapPanelStyles = styled.div`
     .hide-mobile {
       display: none;
     }
+    #plus-icon {
+      z-index: 1;
+      bottom: 255px;
+    }
   `}
 `
 

--- a/client/src/styles/CreateTrip.styles.js
+++ b/client/src/styles/CreateTrip.styles.js
@@ -17,7 +17,7 @@ export const MapWrapper = Styled.div`
       visibility: visible;
       cursor: pointer;
       right: 40px;
-      bottom: 40px;
+      bottom: 200px;
       background: white;
       border-radius: 50%;
       position: absolute;


### PR DESCRIPTION
# Description
On mobile (iphone) keyboard would completely obscure and hide the mobile add waypoint button. This PR modifies the css to raise the button higher on both `createTrip` and `singleTrip`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
