### PR TITLE
[Bug Fix] Add gesture handling option to map for mobile UX

### DIFF
--- a/client/src/components/Maps/createTrip/index.js
+++ b/client/src/components/Maps/createTrip/index.js
@@ -26,6 +26,7 @@ class CreateTripMap extends React.Component {
       {
         center: userCenter ? userCenter : { lat: 39.0997, lng: -94.5786 },
         zoom: 11,
+        gestureHandling: "greedy",
         disableDefaultUI: true
       }
     )
@@ -156,10 +157,7 @@ class CreateTripMap extends React.Component {
     return (
       <MapWrapper>
         <CreateTripPanel {...props} />
-        <div
-          id="createTripMap"
-          style={{ width: "100%", height: "100%", position: "absolute" }}
-        />
+        <div id="createTripMap" style={{ width: "100%", height: "100%" }} />
         <AddButton addWaypoint={this.addWaypoint} />
       </MapWrapper>
     )

--- a/client/src/components/Maps/singleTrip/index.js
+++ b/client/src/components/Maps/singleTrip/index.js
@@ -69,6 +69,7 @@ class SingleTripMap extends React.Component {
       {
         center: center,
         zoom: 12,
+        gestureHandling: "greedy",
         disableDefaultUI: true
       }
     )

--- a/client/src/components/MobileMapPanel.js
+++ b/client/src/components/MobileMapPanel.js
@@ -78,7 +78,7 @@ const MobileMapPanel = ({ children }) => (
 )
 
 MobileMapPanel.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.element)
+  children: PropTypes.any
 }
 
 export default MobileMapPanel

--- a/client/src/styles/CreateTrip.styles.js
+++ b/client/src/styles/CreateTrip.styles.js
@@ -4,6 +4,8 @@ import { media } from "./theme/mixins"
 export const MapWrapper = Styled.div`
   position:relative;
   margin-left: -50px;
+  overflow-x: hidden;
+  overflow-y: hidden;
   ${media.tablet`
     margin-left: 0;
   `}


### PR DESCRIPTION
# Description
- Remove x/y overflow on createTrip mobile view which resulted in wonky mobile UI behavior

- Add `gestureHandling` option to map during instantiation. This allows the map to be moved with one finger in mobile views. Default was using two fingers to zoom or move, bad, bad , bad
