### PR TITLE
[Bug Fix] - Mobile map views now have consistent add waypoint functionality

### DIFF
--- a/client/src/components/Maps/singleTrip/activePanel.js
+++ b/client/src/components/Maps/singleTrip/activePanel.js
@@ -167,6 +167,7 @@ class ActiveTripPanel extends React.Component {
         }
       })
       markers.push(marker)
+      return null
     })
     this.setState({ markers })
   }

--- a/client/src/components/Maps/singleTrip/index.js
+++ b/client/src/components/Maps/singleTrip/index.js
@@ -13,7 +13,9 @@ import { media } from "../../../styles/theme/mixins"
 const SingleTripMapStyles = styled.div`
   width: 100%;
   height: 100%;
-  position: absolute;
+  position: relative;
+  overflow-x: hidden;
+  overflow-y: hidden;
   margin-left: -50px;
   ${media.tablet`
    margin-left: 0;

--- a/client/src/components/Maps/singleTrip/tripPanel.js
+++ b/client/src/components/Maps/singleTrip/tripPanel.js
@@ -31,7 +31,7 @@ import * as s from "./components"
 import { SERVER_URI } from "../../../config"
 import Waypoint from "./Waypoint"
 import MobileMapPanel from "../../MobileMapPanel"
-import marker from "../../icons/orange-marker.svg"
+import mapMarker from "../../icons/orange-marker.svg"
 import startMarker from "../../icons/green-marker.svg"
 import endMarker from "../../icons/black-marker.svg"
 import { numOfSamples, metersToFeet, metersToMiles } from "../../ElevationChart"
@@ -116,6 +116,13 @@ class TripPanel extends React.Component {
   }
 
   addWaypoint = () => {
+    const { maps } = window.google
+    const icon = {
+      url: mapMarker,
+      anchor: new maps.Point(15, 30),
+      scaledSize: new maps.Size(30, 30),
+      labelOrigin: new maps.Point(15, 13)
+    }
     const index = this.state.markers.length
     const marker = new window.google.maps.Marker({
       position: window.map.getCenter(),
@@ -123,7 +130,8 @@ class TripPanel extends React.Component {
       draggable: true,
       title: (index + 1).toString(),
       label: (index + 1).toString(),
-      index: index
+      index: index,
+      icon: icon
     })
     marker.addListener("dragend", ev => {
       const waypoints = this.state.trip.waypoints.map((item, i) => {
@@ -168,7 +176,7 @@ class TripPanel extends React.Component {
         ...baseIcon
       },
       marker: {
-        url: marker,
+        url: mapMarker,
         ...baseIcon
       }
     }

--- a/client/src/components/MobileMapPanel.js
+++ b/client/src/components/MobileMapPanel.js
@@ -63,16 +63,6 @@ const MobileMapPanelStyles = styled.div`
       color: white;
     }
   }
-
-  ${media.tablet`
-    .hide-mobile {
-      display: none;
-    }
-    #plus-icon {
-      z-index: 1;
-      bottom: 255px;
-    }
-  `}
 `
 
 const MobileMapPanel = ({ children }) => (

--- a/client/src/styles/CreateTrip.styles.js
+++ b/client/src/styles/CreateTrip.styles.js
@@ -18,6 +18,7 @@ export const MapWrapper = Styled.div`
     ${media.tablet`
       visibility: visible;
       cursor: pointer;
+      z-index: 1;
       right: 40px;
       bottom: 200px;
       background: white;


### PR DESCRIPTION
# Description
- Add waypoint icon for `singleTrip` did not mirror the alignment on `createTrip`
- `singleTrip` still had overflow issues viewing on mobile device. Hopefully that's been resolved, but won't be sure until this has been merged so I can test
- Adding a new waypoint from `singleTrip` view now creates our custom mapMarker instead of the default one provided by google maps
- In `activePanel` arrow callback function was generating a react warning because nothing was being returned inside of it. I simply added `return null` to the end.