### PR TITLE
[Bug Fix] Mobile trip card image was too large for it's container

### DIFF
--- a/client/src/components/TripCard.js
+++ b/client/src/components/TripCard.js
@@ -46,12 +46,14 @@ const Card = ({
         >
           {archived ? "Unarchive" : "Archive"}
         </Button>
-        <Button
-          className={`btn-tertiary ${trip.isPublic ? "btn-gray" : ""}`}
-          onClick={() => togglePublic(trip.id, userId)}
-        >
-          {trip.isPublic ? "Make Private" : "Share!"}
-        </Button>
+        {!isArchivedTripRoute && (
+          <Button
+            className={`btn-tertiary ${trip.isPublic ? "btn-gray" : ""}`}
+            onClick={() => togglePublic(trip.id, userId)}
+          >
+            {trip.isPublic ? "Make Private" : "Share!"}
+          </Button>
+        )}
         {isArchivedTripRoute && (
           <Button className="btn-tertiary" onClick={() => repeatTrip(trip)}>
             Repeat

--- a/client/src/styles/TripCard.styles.js
+++ b/client/src/styles/TripCard.styles.js
@@ -1,5 +1,4 @@
 import styled from "styled-components"
-import { media } from "./theme/mixins"
 
 export const TripCardStyles = styled.div`
   display: flex;

--- a/client/src/styles/TripCard.styles.js
+++ b/client/src/styles/TripCard.styles.js
@@ -82,9 +82,10 @@ export const TripCardStyles = styled.div`
     align-items: center;
     overflow: hidden;
 
-    ${media.tablet`
+    @media (max-width: 55.875em) {
+      height: 131px;
       width: 100%;
-    `}
+    }
 
     img {
       transition: all 1.86s ease;


### PR DESCRIPTION
# Description
- Set mobile trip image to be a fixed size. Somehow this got changed and the image was pushing all the card content outside of the card

- Remove the share button on an Archived Trip Card. On mobile, this extra button didn't space well with the other two. There simply isn't enough space and the cards are already a good size. I think we are okay with only having the share toggle be present on the active trips
